### PR TITLE
Add support for the venerable M4 language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1917,6 +1917,15 @@ M:
   - .m
   tm_scope: source.lisp
   ace_mode: lisp
+  
+M4:
+  type: programming
+  extensions:
+  - .m4
+  filenames:
+  - configure.ac
+  tm_scope: none
+  ace_mode: text
 
 MTML:
   type: markup

--- a/samples/M4/ax_ruby_devel.m4
+++ b/samples/M4/ax_ruby_devel.m4
@@ -1,0 +1,172 @@
+# ===========================================================================
+#       http://www.gnu.org/software/autoconf-archive/ax_ruby_devel.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_RUBY_DEVEL([version])
+#
+# DESCRIPTION
+#
+#   This macro checks for Ruby and tries to get the include path to
+#   'ruby.h'. It provides the $(RUBY_CPPFLAGS) and $(RUBY_LDFLAGS) output
+#   variables. It also exports $(RUBY_EXTRA_LIBS) for embedding Ruby in your
+#   code.
+#
+#   You can search for some particular version of Ruby by passing a
+#   parameter to this macro, for example "1.8.6".
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Rafal Rzepecki <divided.mind@gmail.com>
+#   Copyright (c) 2008 Sebastian Huber <sebastian-huber@web.de>
+#   Copyright (c) 2008 Alan W. Irwin
+#   Copyright (c) 2008 Rafael Laboissiere <rafael@laboissiere.net>
+#   Copyright (c) 2008 Andrew Collier
+#   Copyright (c) 2008 Matteo Settenvini <matteo@member.fsf.org>
+#   Copyright (c) 2008 Horst Knorr <hk_classes@knoda.org>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 11
+
+AC_DEFUN([AX_RUBY_DEVEL],[
+    AC_REQUIRE([AX_WITH_RUBY])
+    AS_IF([test -n "$1"], [AX_PROG_RUBY_VERSION([$1])])
+
+    #
+    # Check if you have mkmf, else fail
+    #
+    AC_MSG_CHECKING([for the mkmf Ruby package])
+    ac_mkmf_result=`$RUBY -rmkmf -e ";" 2>&1`
+    if test -z "$ac_mkmf_result"; then
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([cannot import Ruby module "mkmf".
+Please check your Ruby installation. The error was:
+$ac_mkmf_result])
+    fi
+
+    #
+    # Check for Ruby include path
+    #
+    AC_MSG_CHECKING([for Ruby include path])
+    if test -z "$RUBY_CPPFLAGS"; then
+        ruby_path=`$RUBY -rmkmf -e 'print Config::CONFIG[["archdir"]]'`
+        if test -n "${ruby_path}"; then
+                ruby_path="-I$ruby_path"
+        fi
+        RUBY_CPPFLAGS=$ruby_path
+    fi
+    AC_MSG_RESULT([$RUBY_CPPFLAGS])
+    AC_SUBST([RUBY_CPPFLAGS])
+
+    #
+    # Check for Ruby library path
+    #
+    AC_MSG_CHECKING([for Ruby library path])
+    if test -z "$RUBY_LDFLAGS"; then
+        RUBY_LDFLAGS=`$RUBY -rmkmf -e 'print Config::CONFIG[["LIBRUBYARG_SHARED"]]'`
+    fi
+    AC_MSG_RESULT([$RUBY_LDFLAGS])
+    AC_SUBST([RUBY_LDFLAGS])
+
+    #
+    # Check for site packages
+    #
+    AC_MSG_CHECKING([for Ruby site-packages path])
+    if test -z "$RUBY_SITE_PKG"; then
+        RUBY_SITE_PKG=`$RUBY -rmkmf -e 'print Config::CONFIG[["sitearchdir"]]'`
+    fi
+    AC_MSG_RESULT([$RUBY_SITE_PKG])
+    AC_SUBST([RUBY_SITE_PKG])
+
+    #
+    # libraries which must be linked in when embedding
+    #
+    AC_MSG_CHECKING(ruby extra libraries)
+    if test -z "$RUBY_EXTRA_LIBS"; then
+       RUBY_EXTRA_LIBS=`$RUBY -rmkmf -e 'print Config::CONFIG[["SOLIBS"]]'`
+    fi
+    AC_MSG_RESULT([$RUBY_EXTRA_LIBS])
+    AC_SUBST(RUBY_EXTRA_LIBS)
+
+    #
+    # linking flags needed when embedding
+    # (is it even needed for Ruby?)
+    #
+    # AC_MSG_CHECKING(ruby extra linking flags)
+    # if test -z "$RUBY_EXTRA_LDFLAGS"; then
+    # RUBY_EXTRA_LDFLAGS=`$RUBY -rmkmf -e 'print Config::CONFIG[["LINKFORSHARED"]]'`
+    # fi
+    # AC_MSG_RESULT([$RUBY_EXTRA_LDFLAGS])
+    # AC_SUBST(RUBY_EXTRA_LDFLAGS)
+
+    # this flags breaks ruby.h, and is sometimes defined by KDE m4 macros
+    CFLAGS="`echo "$CFLAGS" | sed -e 's/-std=iso9899:1990//g;'`"
+    #
+    # final check to see if everything compiles alright
+    #
+    AC_MSG_CHECKING([consistency of all components of ruby development environment])
+    AC_LANG_PUSH([C])
+    # save current global flags
+    ac_save_LIBS="$LIBS"
+    LIBS="$ac_save_LIBS $RUBY_LDFLAGS"
+    ac_save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$ac_save_CPPFLAGS $RUBY_CPPFLAGS"
+    AC_TRY_LINK([
+        #include <ruby.h>
+    ],[
+        ruby_init();
+    ],[rubyexists=yes],[rubyexists=no])
+
+    AC_MSG_RESULT([$rubyexists])
+
+    if test ! "$rubyexists" = "yes"; then
+       AC_MSG_ERROR([
+  Could not link test program to Ruby. Maybe the main Ruby library has been
+  installed in some non-standard library path. If so, pass it to configure,
+  via the LDFLAGS environment variable.
+  Example: ./configure LDFLAGS="-L/usr/non-standard-path/ruby/lib"
+  ============================================================================
+   ERROR!
+   You probably have to install the development version of the Ruby package
+   for your distribution.  The exact name of this package varies among them.
+  ============================================================================
+       ])
+      RUBY_VERSION=""
+    fi
+    AC_LANG_POP
+    # turn back to default flags
+    CPPFLAGS="$ac_save_CPPFLAGS"
+    LIBS="$ac_save_LIBS"
+
+    #
+    # all done!
+    #
+])

--- a/samples/M4/configure.ac
+++ b/samples/M4/configure.ac
@@ -1,0 +1,143 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ(2.68)
+AC_INIT([GARDEN], 
+	[1.0.9], 
+	[bubla@users.sourceforge.net])
+AC_CONFIG_AUX_DIR([build-aux])
+AM_INIT_AUTOMAKE([-Wall])
+AC_CONFIG_SRCDIR([src/input.h])
+AC_CONFIG_HEADERS([src/configure.h])
+AC_CONFIG_MACRO_DIR([m4])
+
+AC_ARG_ENABLE([debug],
+	      [AS_HELP_STRING([--enable-debug],
+			   [Builds the debug version of the library [[default = no]]]) ],
+	      [],
+	      [enable_debug="no"])
+
+AS_IF([test "x$enable_debug" = "xyes"],
+      [CFLAGS="${CFLAGS} -g -O0"])
+
+# Checks for programs.
+AC_PROG_CC
+AC_PROG_LIBTOOL
+LT_PROG_RC
+
+AC_CANONICAL_HOST
+
+dnl
+dnl Check whether it makes sense to install a garden.desktop file
+dnl
+AC_CHECK_PROG([have_freedesktop],
+	      [update-desktop-database],
+	      [yes])
+
+AM_CONDITIONAL([HAVE_FREEDESKTOP],
+	       [test "x$have_freedesktop" = "xyes"])
+
+AM_CONDITIONAL([WANT_FREEDESKTOP],
+	       [test "x$enable_desktop_install" = "xyes"])
+
+AC_ARG_ENABLE([desktop-install],
+	      [AS_HELP_STRING([--enable-desktop-install],
+			      [Whether you want to install the garden.desktop file if applicable. !!! DO NOT USE if you are a PACKAGER!!!])]
+	      )
+
+AS_CASE([$host],
+        [*mingw* | *cygwin*],
+        [AC_DEFINE([WINDOWS_VERSION],
+ 		   [1],
+		   [Define when building for Windows])
+         windows_version="yes"])
+
+AM_CONDITIONAL([WINDOWS_VERSION],
+	       [test "x$windows_version" = "xyes" ])
+
+dnl now the datadir specification, that is useful if one does want to play without installing
+AC_ARG_ENABLE([datadir],
+	      [AS_HELP_STRING([--enable-datadir=path-to-your-garden-datafiles],
+			      [Normally you dont have to use this, but it is handy when you want to play the game without installing it or if you want to use already installed data. In the first case, use for instance --enable-datadir=`pwd`/data (if it makes sense)])], 
+	      [DATADIR_NAME="$enableval"],
+	      [DATADIR_NAME='$(datadir)/'garden])
+
+# Sets the data subdirectory
+AC_SUBST([DATADIR_NAME])
+
+# Checks for libraries.
+AC_CHECK_HEADER([allegro.h],
+		[],
+		[have_allegro="no"
+		 AC_MSG_ERROR([You don't even have Allegro headers... Get Allegro first!]) ])
+
+AC_CHECK_LIB([m], [sin])
+
+test "x$host_os" != "x$build_os" && CROSS_COMPILING="yes"
+
+try_link_allegro ()
+{
+	LIBS_SAVE=$LIBS
+	LIBS="$LIBS $1"
+	AC_MSG_CHECKING([for Allegro using $1])
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT
+					 [ #include <allegro.h> ]],
+					[allegro_init();])END_OF_MAIN() ],
+		       [have_allegro="yes"],
+		       [have_allegro="no"])
+	AC_MSG_RESULT([$have_allegro])
+	LIBS=$LIBS_SAVE
+	AS_IF([test "x$have_allegro" == "xyes"],
+	      [return 0],
+	      [return 1])
+}
+# first check for 'official allegro'
+# The official allegro does not support cross-compiling, though...
+AM_PATH_ALLEGRO([4.2.0]) 
+
+try_link_allegro "$allegro_LIBS"
+AS_IF([test "x$?" == "x0"],
+      [[LIBS="$LIBS $allegro_LIBS"
+       ALLEGRO_LIB=`echo $allegro_LIBS | sed -e 's/.*-l\([^[:blank:]]*\).*/\1/'`
+       have_allegro="yes"]])
+
+ALLEGRO_RELEASE_LIBS="alleg alleg42 alleg44"
+ALLEGRO_DEBUG_LIBS="alld42 alleg44-debug"
+AS_IF([test "x$enable_debug" = "xyes"],
+      [ALLEGRO_LIBS="$ALLEGRO_DEBUG_LIBS $ALLEGRO_RELEASE_LIBS"],
+      [ALLEGRO_LIBS="$ALLEGRO_RELEASE_LIBS $ALLEGRO_DEBUG_LIBS"])
+
+for lib in $ALLEGRO_LIBS
+do
+	ldflag="-l$lib"
+	AS_IF([test "x$have_allegro" == "xyes"],
+	      [break])
+	try_link_allegro $ldflag
+	AS_IF([test "x$?" == "x0"],
+	      [LIBS="$LIBS $ldflag"
+	       ALLEGRO_LIB="$lib"
+	       have_allegro="yes"])
+done
+
+AS_IF([test "x$have_allegro" != "xyes"],
+      [AC_MSG_ERROR([Unable to find Allegro game programming library 4.2, check out www.allegro.cc (or your distro repositories if you use a unix-like system)]) ])
+
+# Checks for header files.
+AC_CHECK_HEADERS([string.h sys/stat.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_C_INLINE
+AC_HEADER_STDBOOL
+
+# Checks for library functions.
+
+AC_SUBST([ALLEGRO_LIB])
+
+AC_CONFIG_FILES([Makefile
+                 src/Makefile
+		 data/Makefile
+		 resources/Makefile
+	 	 docs/garden.doxyfile
+		 pkgs/w32/winstaller.nsi])
+
+AC_OUTPUT

--- a/samples/M4/htmlgen.m4
+++ b/samples/M4/htmlgen.m4
@@ -1,0 +1,38 @@
+dnl Took from https://en.wikipedia.org/wiki/M4_(computer_language)
+divert(-1)
+
+M4 has multiple output queues that can be manipulated with the
+`divert' macro. Valid queues range from 0 to 10, inclusive, with
+the default queue being 0.
+
+Calling the `divert' macro with an invalid queue causes text to be
+discarded until another call.  Note that even while output is being
+discarded, quotes around `divert' and other macros are needed to
+prevent expansion.
+
+# Macros aren't expanded within comments, meaning that keywords such
+# as divert and other built-ins may be used without consequence.
+
+# HTML utility macro:
+
+define(`H2_COUNT', 0)
+
+# The H2_COUNT macro is redefined every time the H2 macro is used:
+
+define(`H2',
+	`define(`H2_COUNT', incr(H2_COUNT))<h2>H2_COUNT. $1</h2>')
+
+divert(1)dnl
+dnl
+dnl The dnl macro causes m4 to discard the rest of the line, thus
+dnl preventing unwanted blank lines from appearing in the output.
+dnl
+H2(First Section)
+H2(Second Section)
+H2(Conclusion)
+dnl
+divert(0)dnl
+dnl
+<HTML>
+undivert(1)dnl One of the queues is being pushed to output.
+</HTML>

--- a/samples/M4/list.m4
+++ b/samples/M4/list.m4
@@ -1,0 +1,46 @@
+m4_define([m4_list_declare], [m4_do(
+	[m4_define([$1_GET], [m4_expand([m4_list_nth([$1], $][1)])])],
+	[m4_define([$1_FOREACH], [m4_foreach([item], [m4_dquote_elt(m4_list_contents([$1]))], m4_quote($][1))])],
+)])
+
+m4_define([m4_list_add], [m4_do(
+	[m4_pushdef([_LIST_NAME], [[_LIST_$1]])],
+	[m4_ifndef(_LIST_NAME,
+		[m4_define(_LIST_NAME, m4_dquote(m4_escape([$2])))],
+		[m4_define(_LIST_NAME, m4_dquote(m4_list_contents([$1]), m4_escape([$2])))],
+	)],
+	[m4_popdef([_LIST_NAME])],
+)])
+
+m4_define([m4_list_contents], [m4_do(
+	[m4_pushdef([_LIST_NAME], [[_LIST_$1]])],
+	[m4_ifndef(_LIST_NAME, [], m4_quote(_LIST_NAME))],
+	[m4_popdef([_LIST_NAME])],
+)])
+
+m4_define([m4_list_nth], [m4_argn([$2], m4_list_contents([$1]))])
+
+m4_define([m4_list_pop_front], [m4_do(
+	[m4_pushdef([_LIST_NAME], [[_LIST_$1]])],
+	[m4_car(m4_unquote(_LIST_NAME))],
+	[m4_define(_LIST_NAME, m4_cdr(m4_unquote(_LIST_NAME)))],
+	[m4_popdef([_LIST_NAME])],
+)])
+
+m4_define([m4_list_pop_back], [m4_do(
+	[m4_pushdef([_LIST_NAME], [[_LIST_$1]])],
+	[m4_define(_LIST_NAME, m4_dquote(m4_reverse(m4_unquote(_LIST_NAME))))],
+	[m4_list_pop_front([$1])],
+	[m4_define(_LIST_NAME, m4_dquote(m4_reverse(m4_unquote(_LIST_NAME))))],
+	[m4_popdef([_LIST_NAME])],
+)])
+
+dnl
+dnl $1: List name
+dnl $2: What
+dnl $3: If contains
+dnl $4: If not
+m4_define([m4_list_contains], [m4_do(
+	[m4_foreach([item], m4_list_contents([$1]), m4_if(item, [$2], [[$3]], [[$4]]))]
+)])
+


### PR DESCRIPTION
m4 is a general-purpose macro processor designed by Brian Kernighan and Dennis Ritchie. GNU M4 (the interpreter) also has built-in functions for including files, running shell commands, doing arithmetic, etc. 

Since the `autoconf` project uses `m4`, the language is very often used to fine-tune the build process of some `C/C++` projects. However, `m4` can be used on its own.

On the technical side, I think that it is a big luck that the `.m4` extension is unoccupied. The language has a very free-form syntax and it is often used as code generator, so identifying `m4` code using statistical methods seems impossible to me.

A huge number of projects make use of `m4`: 
* https://github.com/search?p=1&q=extension:m4+NOT+nothack&ref=searchresults
* https://github.com/search?utf8=✓&q=filename:configure.ac+NOT+nothack&ref=searchresults